### PR TITLE
Give new combatants full activations if combat is started

### DIFF
--- a/src/modules/lancer-combat.ts
+++ b/src/modules/lancer-combat.ts
@@ -164,7 +164,10 @@ export class LancerCombatant extends Combatant {
           break;
       }
       this.data.update({
-        [`flags.${module}.activations`]: { max: activations },
+        [`flags.${module}.activations`]: {
+          max: activations,
+          value: (this.parent?.round ?? 0) > 0 ? activations : 0,
+        },
       });
     }
   }


### PR DESCRIPTION
Rather than requiring GMs to add combatants that come in later on the
previous turn, check if the round is greater than 0 and if so, give the
new combatant full activations.
